### PR TITLE
Fixed Incredibly Minor Typos (Closes #18)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Space 2019</title>
+    <title>Space 2020</title>
     <link href="https://fonts.googleapis.com/css?family=Lato|Rubik&display=swap" rel="stylesheet">
   </head>
   <body>

--- a/src/pages/page2/index.tsx
+++ b/src/pages/page2/index.tsx
@@ -27,7 +27,7 @@ const Page2: React.FC = () => {
           the place to be!
           <br />
           <br />
-          SPACE will be held March 99 2020.
+          SPACE will be held March 9th 2020.
         </p>
         <img className="astro" src={astro} alt="astro" />
       </div>


### PR DESCRIPTION
Fixed
- Title from `2019` to `2020`
- March `99` to March `9th`

